### PR TITLE
Rename test classes

### DIFF
--- a/jqwik-starter-bach/test.my.modules/test/java/test/my/modules/TestMyCalculatorExamples.java
+++ b/jqwik-starter-bach/test.my.modules/test/java/test/my/modules/TestMyCalculatorExamples.java
@@ -4,7 +4,7 @@ import my.example.project.*;
 import net.jqwik.api.*;
 import org.assertj.core.api.*;
 
-class MyCalculatorExamples {
+class TestMyCalculatorExamples {
 
 	@Example
 	void summingUpZeros() {

--- a/jqwik-starter-bach/test.my.modules/test/java/test/my/modules/TestMyCalculatorProperties.java
+++ b/jqwik-starter-bach/test.my.modules/test/java/test/my/modules/TestMyCalculatorProperties.java
@@ -5,7 +5,7 @@ import net.jqwik.api.*;
 import net.jqwik.api.constraints.*;
 import org.assertj.core.api.*;
 
-class MyCalculatorProperties {
+class TestMyCalculatorProperties {
 
 	@Property
 	boolean sumsOfSmallPositivesAreAlwaysPositive(@ForAll @Size(min = 1, max = 10) @IntRange(min = 1, max = 1000) int[] addends) {


### PR DESCRIPTION
## Overview

Rename test classes to match default filter applied the JUnit Platform's Console Launcher.

```text
  -n, --include-classname=PATTERN
                             Provide a regular expression to include only classes whose
                               fully qualified names match. To avoid loading classes
                               unnecessarily, the default pattern only includes class
                               names that begin with "Test" or end with "Test" or
                               "Tests". When this option is repeated, all patterns will
                               be combined using OR semantics. Default: [^(Test.*|.+[.$]
                               Test.*|.*Tests?)$]
```

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
